### PR TITLE
Fix naming lints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,11 +59,11 @@ use std::collections::BTreeSet;
 use std::sync::{Mutex, MutexGuard, PoisonError};
 
 #[doc(hidden)]
-pub struct __MessagesSet {
+pub struct MessagesSet {
     inner: Mutex<BTreeSet<String>>,
 }
 
-impl __MessagesSet {
+impl MessagesSet {
     #[must_use]
     pub fn new() -> Self {
         Self {
@@ -93,14 +93,14 @@ impl __MessagesSet {
 macro_rules! log_once {
     (@CREATE STATIC) => ({
         use ::std::sync::Once;
-        static mut __SEEN_MESSAGES: *const $crate::__MessagesSet = 0 as *const _;
+        static mut SEEN_MESSAGES: *const $crate::MessagesSet = 0 as *const _;
         static ONCE: Once = Once::new();
         unsafe {
             ONCE.call_once(|| {
-                let singleton = $crate::__MessagesSet::new();
-                __SEEN_MESSAGES = ::std::mem::transmute(Box::new(singleton));
+                let singleton = $crate::MessagesSet::new();
+                SEEN_MESSAGES = ::std::mem::transmute(Box::new(singleton));
             });
-            &(*__SEEN_MESSAGES)
+            &(*SEEN_MESSAGES)
         }
     });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,11 +107,10 @@ macro_rules! log_once {
     // log_once!(target: "my_target", Level::Info, "Some {}", "logging")
     (target: $target:expr, $lvl:expr, $($arg:tt)+) => ({
         let message = format!($($arg)+);
-        #[allow(non_snake_case)]
-        let __SEEN_MESSAGES = $crate::log_once!(@CREATE STATIC);
-        let mut seen_messages = __SEEN_MESSAGES.lock().expect("Mutex was poisonned");
+        let seen_messages_mutex = $crate::log_once!(@CREATE STATIC);
+        let mut seen_messages_lock = seen_messages_mutex.lock().expect("Mutex was poisonned");
         let event = String::from(stringify!($target)) + stringify!($lvl) + message.as_ref();
-        if seen_messages.insert(event) {
+        if seen_messages_lock.insert(event) {
             $crate::log::log!(target: $target, $lvl, "{}", message);
         }
     });


### PR DESCRIPTION
The macros declared variables with names that cargo doesn't like, leading to warnings in user code.